### PR TITLE
Fix clone issues for cross validation

### DIFF
--- a/sknn/mlp.py
+++ b/sknn/mlp.py
@@ -159,6 +159,8 @@ class BaseMLP(sklearn.base.BaseEstimator):
             self.learning_rule = Momentum(learning_momentum)
         elif learning_rule == 'rmsprop':
             self.learning_rule = RMSProp()
+        elif not isinstance(learning_rule,str):
+            self.learning_rule=learning_rule
         else:
             raise NotImplementedError(
                 "Learning rule type `%s` is not supported." % learning_rule)

--- a/sknn/mlp.py
+++ b/sknn/mlp.py
@@ -159,6 +159,8 @@ class BaseMLP(sklearn.base.BaseEstimator):
             self.learning_rule = Momentum(learning_momentum)
         elif learning_rule == 'rmsprop':
             self.learning_rule = RMSProp()
+        #accept the learning rule if it's not a string
+        #otherwise it fails when cloning classifiers during cross validation
         elif not isinstance(learning_rule,str):
             self.learning_rule=learning_rule
         else:


### PR DESCRIPTION
Hi,

I found this minor bug when integrating this package with some code what we already had
```
skf = StratifiedKFold(features.labels, FOLDS) #Stratified cross validation with FOLDS folds

#Initalise variables to record best classifier
maxScore = -1
self.maxClassifier = ""

for c in self.classifier.keys():
    #Calculate performance
    scores = cross_val_score(self.classifier[c], features.features, features.labels, cv=skf)
    score = np.mean(scores)*100
```
it complained as the clone method wasn't working properly. it failed because the learning_rule won't accept already created objects as input:
https://github.com/aigamedev/scikit-neuralnetwork/blob/master/sknn/mlp.py#L156

cheers!
