### PR TITLE
Support prediction without fitting, with randomly initialized weights.

### DIFF
--- a/sknn/tests/test_classifier.py
+++ b/sknn/tests/test_classifier.py
@@ -23,7 +23,12 @@ class TestClassifierFunctionality(unittest.TestCase):
         self.nn.partial_fit(a_in, a_out, classes=[0,1,2,3])
         self.nn.partial_fit(a_in*2.0, a_out+1, classes=[0,1,2,3])
 
-    def test_PredictUninitialized(self):
+    def test_PredictUninitializedNoUnitCount(self):
+        a_in = numpy.zeros((8,16))
+        assert_raises(AssertionError, self.nn.predict, a_in)
+
+    def test_PredictUninitializedNoLabels(self):
+        self.nn.layers[-1].units = 4
         a_in = numpy.zeros((8,16))
         assert_raises(ValueError, self.nn.predict, a_in)
 

--- a/sknn/tests/test_conv.py
+++ b/sknn/tests/test_conv.py
@@ -84,6 +84,46 @@ class TestConvolution(unittest.TestCase):
             n_iter=1))
 
 
+class TestConvolutionSpecs(unittest.TestCase):
+
+    def test_SmallSquareKernel(self):
+        nn = MLPR(layers=[
+                    C("Rectifier", channels=4, kernel_shape=(3,3)),
+                    L("Linear", units=5)])
+
+        a_in = numpy.zeros((8,32,32,1))
+        nn._create_specs(a_in)
+        assert_equal(nn.unit_counts, [1024, 30 * 30 * 4, 5])
+
+    def test_HorizontalKernel(self):
+        nn = MLPR(layers=[
+                    C("Rectifier", channels=7, kernel_shape=(16,1)),
+                    L("Linear", units=5)])
+
+        a_in = numpy.zeros((8,16,16,1))
+        nn._create_specs(a_in)
+        assert_equal(nn.unit_counts, [256, 16 * 7, 5])
+
+    def test_VerticalKernel(self):
+        nn = MLPR(layers=[
+                    C("Rectifier", channels=4, kernel_shape=(1,16)),
+                    L("Linear", units=7)])
+
+        a_in = numpy.zeros((8,16,16,1))
+        nn._create_specs(a_in)
+        assert_equal(nn.unit_counts, [256, 16 * 4, 7])
+
+    def test_SquareKernelPool(self):
+        # TODO: After creation the outputs don't seem to correspond; pooling enabled?
+        nn = MLPR(layers=[
+                    C("Rectifier", channels=4, kernel_shape=(3,3), pool_shape=(2,2)),
+                    L("Linear", units=5)])
+
+        a_in = numpy.zeros((8,32,32,1))
+        nn._create_specs(a_in)
+        assert_equal(nn.unit_counts, [1024, 15 * 15 * 4, 5])
+
+
 class TestActivationTypes(unittest.TestCase):
 
     def _run(self, activation):

--- a/sknn/tests/test_linear.py
+++ b/sknn/tests/test_linear.py
@@ -18,9 +18,14 @@ class TestLinearNetwork(unittest.TestCase):
     def test_LifeCycle(self):
         del self.nn
 
-    def test_PredictUninitialized(self):
+    def test_PredictNoOutputUnitsAssertion(self):
         a_in = numpy.zeros((8,16))
-        assert_raises(ValueError, self.nn.predict, a_in)
+        assert_raises(AssertionError, self.nn.predict, a_in)
+
+    def test_AutoInitializeWithOutputUnits(self):
+        self.nn.layers[-1].units = 4
+        a_in = numpy.zeros((8,16))
+        self.nn.predict(a_in)
 
     def test_FitAutoInitialize(self):
         a_in, a_out = numpy.zeros((8,16)), numpy.zeros((8,4))
@@ -87,7 +92,7 @@ class TestSerializedNetwork(TestLinearNetwork):
         # was serialized and deserialized.
         pass
 
-    def test_PredictUninitialized(self):
+    def test_PredictNoOutputUnitsAssertion(self):
         # Override base class test, this is not initialized but it
         # should be able to predict without throwing assert.
         assert_true(self.nn.is_initialized)


### PR DESCRIPTION
The base multi-layer perceptron class does not require training before predicting, it can self-initialise if given the correct output unit count.  This also improves the code, breaking down the larger `_initialize()` function.

Closes #31.