### PR TITLE
Serialization works even if the MLP has not been trained

### DIFF
--- a/sknn/mlp.py
+++ b/sknn/mlp.py
@@ -302,11 +302,14 @@ class MultiLayerPerceptron(NeuralNetwork, sklearn.base.BaseEstimator):
         return not (self.mlp is None or self.f is None)
 
     def __getstate__(self):
-        assert self.mlp is not None,\
-            "The neural network has not been initialized."
-
         d = self.__dict__.copy()
-        d['weights'] = self._mlp_to_array()
+
+        # If the MLP does not exist, then the client code is trying to serialize
+        # this object to communicate between multiple processes.
+        if self.mlp is not None:
+            d['weights'] = self._mlp_to_array()
+        else:
+            log.warning("Serializing a neural network that was not initialized.")
 
         for k in ['ds', 'vs', 'f', 'trainer', 'mlp']:
             if k in d:
@@ -320,7 +323,11 @@ class MultiLayerPerceptron(NeuralNetwork, sklearn.base.BaseEstimator):
         self.__dict__.update(d)
         for k in ['ds', 'vs', 'f', 'trainer', 'mlp']:
             setattr(self, k, None)
-        self._create_mlp()
+
+        # Only create the MLP if the weights were serialized. Otherwise, it
+        # may have been serialized for multiprocessing reasons pre-training.
+        if self.weights is not None:
+            self._create_mlp()
 
     def _array_to_mlp(self, array, nn):
         for layer, (weights, biases) in zip(nn.layers, array):

--- a/sknn/tests/test_conv.py
+++ b/sknn/tests/test_conv.py
@@ -222,13 +222,11 @@ class TestSerialization(unittest.TestCase):
                 L("Linear")],
             n_iter=1)
 
-    def test_SerializeFail(self):
+    def test_SerializeEmpty(self):
         buf = io.BytesIO()
-        assert_raises(AssertionError, pickle.dump, self.nn, buf)
-
-    def test_SerializeCorrect(self):
-        a_in, a_out = numpy.zeros((8,32,16,1)), numpy.zeros((8,4))
-        self.nn.fit(a_in, a_out)
+        pickle.dump(self.nn, buf)
+        buf.seek(0)
+        nn = pickle.load(buf)
 
         buf = io.BytesIO()
         pickle.dump(self.nn, buf)

--- a/sknn/tests/test_conv.py
+++ b/sknn/tests/test_conv.py
@@ -234,7 +234,6 @@ class TestSerialization(unittest.TestCase):
         buf.seek(0)
         nn = pickle.load(buf)
 
-        assert_is_not_none(nn.mlp)
         assert_equal(nn.layers, self.nn.layers)
 
 

--- a/sknn/tests/test_linear.py
+++ b/sknn/tests/test_linear.py
@@ -62,9 +62,11 @@ class TestSerialization(unittest.TestCase):
     def setUp(self):
         self.nn = MLPR(layers=[L("Linear")], n_iter=1)
 
-    def test_SerializeFail(self):
+    def test_SerializeEmpty(self):
         buf = io.BytesIO()
-        assert_raises(AssertionError, pickle.dump, self.nn, buf)
+        pickle.dump(self.nn, buf)
+        buf.seek(0)
+        nn = pickle.load(buf)
 
     def test_SerializeCorrect(self):
         a_in, a_out = numpy.zeros((8,16)), numpy.zeros((8,4))

--- a/sknn/tests/test_sklearn.py
+++ b/sknn/tests/test_sklearn.py
@@ -45,6 +45,13 @@ class TestGridSearchRegressor(unittest.TestCase):
                     n_iter=2)
         clf.fit(self.a_in, self.a_out)
 
+    def test_RandomMultipleJobs(self):
+        clf = RandomizedSearchCV(
+                    self.__estimator__(layers=[L("Softmax", units=12), L("Linear")], n_iter=1),
+                    param_distributions={'hidden0__units': randint(4, 12)},
+                    n_iter=4, n_jobs=4)
+        clf.fit(self.a_in, self.a_out)
+
 
 class TestGridSearchClassifier(TestGridSearchRegressor):
 


### PR DESCRIPTION
Useful for n_jobs=1 in randomised grid search from sklearn.

Closes #64.