### PR TITLE
Docs change

### DIFF
--- a/docs/guide_advanced.rst.bak
+++ b/docs/guide_advanced.rst.bak
@@ -99,7 +99,7 @@ In the cases when you have large numbers of hyper-parameters that you want to tr
     from sklearn.grid_search import RandomizedSearchCV
 
     rs = RandomizedSearchCV(nn, param_grid={
-        'learning_rate': stats.uniform(0.001, 0.05),
+        learning_rate: stats.uniform(0.001, 0.05),
         'hidden0__units': stats.randint(4, 12),
         'hidden0__type': ["Rectifier", "Sigmoid", "Tanh"]})
     rs.fit(a_in, a_out)


### PR DESCRIPTION
Updated guide_advanced to include tick (quote) marks around learning_rate. Code was throwing errors without the quote marks. Did verify that using the quote marks actually implemented a search around the learning rate.