### PR TITLE
sknn unit test date type error

### DIFF
--- a/sknn/backend/lasagne/mlp.py
+++ b/sknn/backend/lasagne/mlp.py
@@ -276,8 +276,6 @@ class MultiLayerPerceptronBackend(BaseBackend):
         for layer, data in zip(nn, array):
             if data is None: continue
             weights, biases = data
-            weights = weights.astype(theano.config.floatX)
-            biases = biases.astype(theano.config.floatX)
 
             while not hasattr(layer, 'W') and not hasattr(layer, 'b'):
                 layer = layer.input_layer
@@ -285,9 +283,9 @@ class MultiLayerPerceptronBackend(BaseBackend):
             ws = tuple(layer.W.shape.eval())
             assert ws == weights.shape, "Layer weights shape mismatch: %r != %r" %\
                                         (ws, weights.shape)
-            layer.W.set_value(weights)
+            layer.W.set_value(weights.astype(theano.config.floatX))
 
             bs = tuple(layer.b.shape.eval())
             assert bs == biases.shape, "Layer biases shape mismatch: %r != %r" %\
                                        (bs, biases.shape)
-            layer.b.set_value(biases)
+            layer.b.set_value(biases.astype(theano.config.floatX))

--- a/sknn/backend/lasagne/mlp.py
+++ b/sknn/backend/lasagne/mlp.py
@@ -276,6 +276,10 @@ class MultiLayerPerceptronBackend(BaseBackend):
         for layer, data in zip(nn, array):
             if data is None: continue
             weights, biases = data
+            if weights.dtype == numpy.float64:
+                weights = weights.astype(numpy.float32)
+            if biases.dtype == numpy.float64:
+                biases = biases.astype(numpy.float32)
 
             while not hasattr(layer, 'W') and not hasattr(layer, 'b'):
                 layer = layer.input_layer

--- a/sknn/backend/lasagne/mlp.py
+++ b/sknn/backend/lasagne/mlp.py
@@ -276,10 +276,8 @@ class MultiLayerPerceptronBackend(BaseBackend):
         for layer, data in zip(nn, array):
             if data is None: continue
             weights, biases = data
-            if weights.dtype == numpy.float64:
-                weights = weights.astype(numpy.float32)
-            if biases.dtype == numpy.float64:
-                biases = biases.astype(numpy.float32)
+            weights = weights.astype(theano.config.floatX)
+            biases = biases.astype(theano.config.floatX)
 
             while not hasattr(layer, 'W') and not hasattr(layer, 'b'):
                 layer = layer.input_layer

--- a/sknn/tests/test_data.py
+++ b/sknn/tests/test_data.py
@@ -4,7 +4,6 @@ from nose.tools import (assert_in, assert_raises, assert_equals, assert_true)
 import logging
 
 import numpy
-import theano
 from sknn.mlp import Regressor as MLPR
 from sknn.mlp import Layer as L, Convolution as C
 
@@ -61,8 +60,8 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters([(weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[0].weights == weights.astype(theano.config.floatX)).all())
-        assert_true((p[0].biases == biases.astype(theano.config.floatX)).all())
+        assert_true((p[0].weights.astype('float32') == weights.astype('float32')).all())
+        assert_true((p[0].biases.astype('float32') == biases.astype('float32')).all())
 
     def test_LayerParamsSkipOneWithNone(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -74,8 +73,8 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters([None, (weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights.astype(theano.config.floatX)).all())
-        assert_true((p[1].biases == biases.astype(theano.config.floatX)).all())
+        assert_true((p[1].weights.astype('float32') == weights.astype('float32')).all())
+        assert_true((p[1].biases.astype('float32') == biases.astype('float32')).all())
 
     def test_SetLayerParamsDict(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -87,5 +86,5 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters({'abcd': (weights, biases)})
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights.astype(theano.config.floatX)).all())
-        assert_true((p[1].biases == biases.astype(theano.config.floatX)).all())
+        assert_true((p[1].weights.astype('float32') == weights.astype('float32')).all())
+        assert_true((p[1].biases.astype('float32') == biases.astype('float32')).all())

--- a/sknn/tests/test_data.py
+++ b/sknn/tests/test_data.py
@@ -57,13 +57,11 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (16,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
-        weights = weights.astype(numpy.float32)
-        biases = biases.astype(numpy.float32)
         nn.set_parameters([(weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[0].weights == weights).all())
-        assert_true((p[0].biases == biases).all())
+        assert_true((p[0].weights == weights.astype(numpy.float32)).all())
+        assert_true((p[0].biases == biases.astype(numpy.float32)).all())
 
     def test_LayerParamsSkipOneWithNone(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -72,13 +70,11 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (32,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
-        weights = weights.astype(numpy.float32)
-        biases = biases.astype(numpy.float32)
         nn.set_parameters([None, (weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights).all())
-        assert_true((p[1].biases == biases).all())
+        assert_true((p[1].weights == weights.astype(numpy.float32)).all())
+        assert_true((p[1].biases == biases.astype(numpy.float32)).all())
 
     def test_SetLayerParamsDict(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -87,10 +83,8 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (32,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
-        weights = weights.astype(numpy.float32)
-        biases = biases.astype(numpy.float32)
         nn.set_parameters({'abcd': (weights, biases)})
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights).all())
-        assert_true((p[1].biases == biases).all())
+        assert_true((p[1].weights == weights.astype(numpy.float32)).all())
+        assert_true((p[1].biases == biases.astype(numpy.float32)).all())

--- a/sknn/tests/test_data.py
+++ b/sknn/tests/test_data.py
@@ -4,6 +4,7 @@ from nose.tools import (assert_in, assert_raises, assert_equals, assert_true)
 import logging
 
 import numpy
+import theano
 from sknn.mlp import Regressor as MLPR
 from sknn.mlp import Layer as L, Convolution as C
 
@@ -60,8 +61,8 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters([(weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[0].weights == weights.astype(numpy.float32)).all())
-        assert_true((p[0].biases == biases.astype(numpy.float32)).all())
+        assert_true((p[0].weights == weights.astype(theano.config.floatX)).all())
+        assert_true((p[0].biases == biases.astype(theano.config.floatX)).all())
 
     def test_LayerParamsSkipOneWithNone(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -73,8 +74,8 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters([None, (weights, biases)])
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights.astype(numpy.float32)).all())
-        assert_true((p[1].biases == biases.astype(numpy.float32)).all())
+        assert_true((p[1].weights == weights.astype(theano.config.floatX)).all())
+        assert_true((p[1].biases == biases.astype(theano.config.floatX)).all())
 
     def test_SetLayerParamsDict(self):
         nn = MLPR(layers=[L("Sigmoid", units=32), L("Linear", name='abcd')])
@@ -86,5 +87,5 @@ class TestNetworkParameters(unittest.TestCase):
         nn.set_parameters({'abcd': (weights, biases)})
         
         p = nn.get_parameters()
-        assert_true((p[1].weights == weights.astype(numpy.float32)).all())
-        assert_true((p[1].biases == biases.astype(numpy.float32)).all())
+        assert_true((p[1].weights == weights.astype(theano.config.floatX)).all())
+        assert_true((p[1].biases == biases.astype(theano.config.floatX)).all())

--- a/sknn/tests/test_data.py
+++ b/sknn/tests/test_data.py
@@ -57,6 +57,8 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (16,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
+        weights = weights.astype(numpy.float32)
+        biases = biases.astype(numpy.float32)
         nn.set_parameters([(weights, biases)])
         
         p = nn.get_parameters()
@@ -70,6 +72,8 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (32,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
+        weights = weights.astype(numpy.float32)
+        biases = biases.astype(numpy.float32)
         nn.set_parameters([None, (weights, biases)])
         
         p = nn.get_parameters()
@@ -83,6 +87,8 @@ class TestNetworkParameters(unittest.TestCase):
         
         weights = numpy.random.uniform(-1.0, +1.0, (32,4))
         biases = numpy.random.uniform(-1.0, +1.0, (4,))
+        weights = weights.astype(numpy.float32)
+        biases = biases.astype(numpy.float32)
         nn.set_parameters({'abcd': (weights, biases)})
         
         p = nn.get_parameters()


### PR DESCRIPTION
In the test_data.py file in folder sknn\tests, when using gpu and setting theano flag to floatX = float32, original data type (numpy.float64) of these two variables (weights and biases) would be wrong so that the unit test would generate 3 errors. In order to solve this problem, I change the date type of these two variables to numpy.float32, and then all the tests are passed.
I'm looking forward to your reply. Thx. :)